### PR TITLE
wait for `$timeout` seconds before failing with no runs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
   status:
     required: true
     default: "any"
+  timeout:
+    default: 30
+  poll_interval:
+    default: 1
   repository:
     default: ${{ github.repository }}
   token:

--- a/get-workflow-run.sh
+++ b/get-workflow-run.sh
@@ -7,10 +7,17 @@
 # - `commit_sha`: The Git commit SHA associated with the workflow run.
 # - `status`: Return workflow runs with this status (e.g. "success", "completed"). Defaults
 #   to "any" for any status.
+# - `timeout`: How long in seconds to wait before exiting with an error if no
+#   run is found for this workflow + commit + status.  Defaults to 10.
+# - `poll_interval`: How long in seconds to sleep between each check for the
+#   workflow run.  Defaults to 1.
 
 set -eo pipefail
 
 status="${status:-any}"
+
+timeout=${timeout:-10}
+poll_interval=${poll_interval:-1}
 
 workflow_id="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/workflows" --jq ".workflows[] | select(.path == \".github/workflows/${workflow_file:?}\").id")"
 echo "workflow-id=${workflow_id:?}" | tee -a "$GITHUB_OUTPUT"
@@ -24,9 +31,18 @@ elif [[ "${status}" != "any" ]]; then
     exit 1
 fi
 
-# Determine the latest workflow run associated with the `commit_sha`
-# https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
-run="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs" -f head_sha="${commit_sha:?}" "${flags[@]}" --jq ".workflow_runs | map(select(.workflow_id == ${workflow_id:?})) | sort_by(.run_number, .run_attempt) | .[-1]")"
+start=$EPOCHSECONDS
+while [[ $((EPOCHSECONDS - start)) -lt $timeout ]]; do
+    # Determine the latest workflow run associated with the `commit_sha`
+    # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository
+    run="$(gh api -X GET --paginate "/repos/{owner}/{repo}/actions/runs" -f head_sha="${commit_sha:?}" "${flags[@]}" --jq ".workflow_runs | map(select(.workflow_id == ${workflow_id:?})) | sort_by(.run_number, .run_attempt) | .[-1]")"
+    if [[ -n "${run}" ]]; then
+        break
+    fi
+
+    sleep "${poll_interval}"
+done
+
 if [[ -z "${run}" ]]; then
     echo "Unable to locate any workflow runs for commit SHA ${commit_sha} and status \"${status}\"." >&2
     exit 1


### PR DESCRIPTION
When using this action as a step in a workflow to get the runs associated with
another workflow for the same commit, there can be a race condition where the
first workflow run has not yet started, so no runs are detected.  This adds a
timeout which defaults to 10s.